### PR TITLE
sync (CI): run on arm64 runners

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -17,7 +17,7 @@ env:
 jobs:
   sync:
     if: github.repository_owner == 'git-for-windows' || github.event.inputs.debug_with_ssh_key != ''
-    runs-on: windows-latest
+    runs-on: [Windows, ARM64]
     environment: sync
     steps:
       - name: clone git-sdk-arm64


### PR DESCRIPTION
Some Pacman updates require post-install scripts to run. Since some of these binaries are native arm64 ones, we should be running these on native arm64 runners, instead of GitHub's x64 ones.

Ref: https://github.com/git-for-windows/git-sdk-arm64/pull/13