### PR TITLE
sync (CI): use powershell instead of pwsh

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -26,7 +26,7 @@ jobs:
           persist-credentials: true
           token: ${{ secrets.PUSH_TOKEN }}
       - name: Update all Pacman packages
-        shell: pwsh
+        shell: powershell
         run: |
           & .\update-via-pacman.ps1
       - name: use git-sdk-arm64's Bash and Git for Windows' git.exe


### PR DESCRIPTION
The self-hosted runners don't have `pwsh` installed, whereas `powershell` is pretty much guaranteed to always work on Windows machines