### PR TITLE
pacman: enable debug mode

### DIFF
--- a/update-via-pacman.ps1
+++ b/update-via-pacman.ps1
@@ -35,7 +35,7 @@ if (!(Test-Path var\log -PathType Container)) {
 }
 
 echo "Run Pacman (First Pass)"
-bash -lc "pacman -Syyu --overwrite=\* --noconfirm"
+bash -lc "pacman --debug -Syyu --overwrite=\* --noconfirm"
 if (!$?) { exit 1 }
 
 # Ensure that the Git for Windows keyring is registered
@@ -68,7 +68,7 @@ if ($type -Match "full system upgrade") {
   echo "No second pass needed"
 } else {
   echo "Run Pacman again (Second Pass) to upgrade the remaining (non-core) packages"
-  bash -lc "pacman -Su --overwrite=\* --noconfirm"
+  bash -lc "pacman --debug -Su --overwrite=\* --noconfirm"
   if (!$?) { exit 1 }
 
   # Ensure that the Git for Windows keyring is registered
@@ -143,4 +143,4 @@ if ($pacnew.Length -gt 0) {
 }
 
 # Wrapping up: re-install mingw-w64-git-extra
-bash -lc "pacman -S --overwrite=\* --noconfirm mingw-w64-clang-aarch64-git-extra"
+bash -lc "pacman --debug -S --overwrite=\* --noconfirm mingw-w64-clang-aarch64-git-extra"


### PR DESCRIPTION
In my local testing, I didn't run into hangs anymore when pacman runs in debug mode. Maybe because it just outputs so many lines? Let's try if it works in CI as well