### PR TITLE
update-via-pacman: install asciidoctor if not present

### DIFF
--- a/update-via-pacman.ps1
+++ b/update-via-pacman.ps1
@@ -99,14 +99,21 @@ if (Test-Path var/lib/pacman/local/mingw-w64-*-asciidoctor-extensions-[0-9]* -Pa
       # Uninstall mingw-w64-asciidoctor-extensions
       test ! -d /var/lib/pacman/local/mingw-w64-$carch-asciidoctor-extensions-[0-9]* || {
         pacman -R --noconfirm mingw-w64-$carch-asciidoctor-extensions &&
-        # Uninstall the `asciidoctor` gem and install `mingw-w64-asciidoctor` instead
+        # Uninstall the `asciidoctor` gem
         gem uninstall asciidoctor
       } || exit 1
-
-      pacman -S --noconfirm mingw-w64-$carch-asciidoctor || exit 1
     done
 '@
-	if (!$?) { die "Could not re-install asciidoctor" }
+	if (!$?) { die "Could not remove asciidoctor-extensions" }
+}
+
+# asciidoctor is needed to build mingw-w64-git. Let's install it if it's not present.
+if (!(Test-Path var/lib/pacman/local/mingw-w64-*-asciidoctor-[0-9]* -PathType Container)) {
+  bash -lc @'
+    set -x
+    pacman -S --noconfirm mingw-w64-clang-aarch64-asciidoctor || exit 1
+'@
+	if (!$?) { die "Could not install asciidoctor" }
 }
 
 # Pacman sometimes writes `.pacnew` files; We want to rename them and let


### PR DESCRIPTION
Successor of https://github.com/git-for-windows/git-sdk-arm64/pull/19

In a recent change, GfW switched from the homegrown `-asciidoctor-extensions` package to the MSYS2-provided `-asciidoctor` one, as there's no need for the former nowadays.

This commit allows `update-via-pacman.ps1` to install the latter package.

Ref: https://github.com/git-for-windows/MINGW-packages/commit/907ead42e93c073c0a37b902df02ef0d08102a99