### PR TITLE
makepkg-git: use AsciiDoctor again

### DIFF
--- a/.sparse/makepkg-git
+++ b/.sparse/makepkg-git
@@ -52,6 +52,14 @@
 /usr/share/makepkg/
 /usr/bin/zstd.exe
 
+# gettext (for makepkg)
+/usr/bin/gettext.exe
+/usr/bin/xgettext.exe
+/usr/bin/msys-gettext*.dll
+
+# The `error_highlight` Ruby gem, needed by `asciidoctor`
+*error_highlight*
+
 # AsciiDoc
 /clangarm64/bin/asciidoc.exe
 /clangarm64/bin/asciidoc-script.py

--- a/.sparse/makepkg-git
+++ b/.sparse/makepkg-git
@@ -60,16 +60,33 @@
 # The `error_highlight` Ruby gem, needed by `asciidoctor`
 *error_highlight*
 
-# AsciiDoc
-/clangarm64/bin/asciidoc.exe
-/clangarm64/bin/asciidoc-script.py
-/clangarm64/bin/python*
-/clangarm64/bin/libpython*.dll
-/clangarm64/lib/python*/
-!/clangarm64/lib/python*/site-packages/
-!/clangarm64/lib/python*/test/
-/clangarm64/lib/python*/site-packages/asciidoc/
-/clangarm64/lib/python*/site-packages/asciidoc*-info/
+# AsciiDoctor
+/clangarm64/bin/asciidoctor
+/clangarm64/bin/ruby.exe
+/clangarm64/bin/ruby*.dll
+/clangarm64/lib/ruby/*/aarch64-mingw-ucrt/rbconfig.rb
+/clangarm64/lib/ruby/*/rubygems.rb
+/clangarm64/lib/ruby/*/rubygems/
+/clangarm64/lib/ruby/*/delegate.rb
+/clangarm64/lib/ruby/*/uri.rb
+/clangarm64/lib/ruby/*/uri/
+/clangarm64/lib/ruby/*/aarch64-mingw-ucrt/stringio.so
+/clangarm64/lib/ruby/*/monitor.rb
+/clangarm64/lib/ruby/*/aarch64-mingw-ucrt/monitor.so
+/clangarm64/lib/ruby/gems/*/gems/asciidoctor-*
+/clangarm64/lib/ruby/gems/*/specifications/asciidoctor-*.gemspec
+/clangarm64/lib/ruby/*/tsort.rb
+/clangarm64/lib/ruby/*/set.rb
+/clangarm64/lib/ruby/*/logger.rb
+/clangarm64/lib/ruby/*/aarch64-mingw-ucrt/enc/encdb.so
+/clangarm64/lib/ruby/*/aarch64-mingw-ucrt/enc/windows_1252.so
+/clangarm64/lib/ruby/*/optparse.rb
+/clangarm64/lib/ruby/*/aarch64-mingw-ucrt/strscan.so
+/clangarm64/lib/ruby/*/pathname.rb
+/clangarm64/lib/ruby/*/aarch64-mingw-ucrt/pathname.so
+/clangarm64/lib/ruby/*/did_you_mean*
+/clangarm64/lib/ruby/*/cgi/util*
+/clangarm64/lib/ruby/*/logger*
 
 # xsltproc (e.g. for Git's user-manual.html)
 /usr/bin/xsltproc.exe

--- a/.sparse/makepkg-git
+++ b/.sparse/makepkg-git
@@ -33,7 +33,7 @@
 /usr/bin/msys-magic*.dll
 /usr/share/misc/magic.mgc
 /usr/bin/bsdtar.exe
-/usr/bin/msys-crypto-1.1.dll
+/usr/bin/msys-crypto-*.dll
 /usr/bin/msys-zstd*.dll
 /usr/bin/msys-nettle*.dll
 /usr/bin/msys-lzma*.dll

--- a/.sparse/minimal-sdk
+++ b/.sparse/minimal-sdk
@@ -227,5 +227,6 @@
 /usr/bin/tput.exe
 /usr/bin/true.exe
 /usr/bin/unzip.exe
+/usr/bin/msys-bz2-[0-9]*.dll
 /usr/bin/xargs.exe
 /usr/bin/zipinfo.exe

--- a/.sparse/minimal-sdk
+++ b/.sparse/minimal-sdk
@@ -218,6 +218,7 @@
 /usr/bin/head.exe
 /usr/bin/rmdir.exe
 /usr/bin/setfacl.exe
+/usr/bin/stat.exe
 /usr/bin/sleep.exe
 /usr/bin/tail.exe
 /usr/bin/tar.exe

--- a/.sparse/minimal-sdk
+++ b/.sparse/minimal-sdk
@@ -50,6 +50,7 @@
 /clangarm64/bin/libssl-*.dll
 /clangarm64/bin/libnghttp2*.dll
 /clangarm64/bin/libidn2-*.dll
+/clangarm64/bin/libpsl*.dll
 /clangarm64/bin/libssh*.dll
 /clangarm64/bin/libunistring-*.dll
 /clangarm64/ssl/certs/ca-bundle.crt

--- a/.sparse/minimal-sdk
+++ b/.sparse/minimal-sdk
@@ -33,6 +33,7 @@
 # The gcc-compat package provides a link from
 # gcc.exe to clang
 /clangarm64/bin/gcc.exe
+/clangarm64/bin/libc++.dll
 
 # gettext (msgfmt)
 /clangarm64/bin/msgfmt.exe

--- a/.sparse/minimal-sdk
+++ b/.sparse/minimal-sdk
@@ -53,6 +53,7 @@
 /clangarm64/bin/libpsl*.dll
 /clangarm64/bin/libssh*.dll
 /clangarm64/bin/libunistring-*.dll
+/clangarm64/etc/ssl/certs/ca-bundle.crt
 /clangarm64/ssl/certs/ca-bundle.crt
 /clangarm64/include/curl/
 


### PR DESCRIPTION
In https://github.com/git-for-windows/git-sdk-arm64/pull/6, we switched the `makepkg-git` SDK artifact in git-sdk-arm64 away from using AsciiDoctor to using AsciiDoc instead. The reason was that the former was not yet supported in the `clangarm64` packages in MSYS2.

In the meantime, AsciiDoctor is not only supported, but now also required to build `mingw-w64-clang-aarch64-git`.

So let's adjust the `makepkg-git` sparse checkout definition accordingly.