### PR TITLE
minimal-sdk: add missing DLLs for clang.exe

### DIFF
--- a/.sparse/minimal-sdk
+++ b/.sparse/minimal-sdk
@@ -21,8 +21,11 @@
 /clangarm64/bin/libgmp-*[0-9].dll
 /clangarm64/bin/libclang.dll
 /clangarm64/bin/libclang-cpp.dll
+/clangarm64/bin/libffi-*[0-9].dll
 /clangarm64/bin/libLLVM-*[0-9].dll
+/clangarm64/bin/liblzma-*[0-9].dll
 /clangarm64/bin/libwinpthread-*[0-9].dll
+/clangarm64/bin/libxml2-*[0-9].dll
 /clangarm64/bin/libzstd.dll
 /clangarm64/bin/llvm-strip.exe
 /clangarm64/bin/windres.exe


### PR DESCRIPTION
While [working on adding](https://github.com/git-for-windows/git-sdk-arm64/pull/22#discussion_r1759812253) a `ci-artifacts` pipeline to `git-sdk-arm64`, which contains a test for `clang.exe`, the command failed because of some missing DLLs.

This PR ensures the missing DLLs will be added to the `minimal-sdk` artifact.