### PR TITLE
makepkg-git: include update-via-pacman.ps1

### DIFF
--- a/.sparse/makepkg-git
+++ b/.sparse/makepkg-git
@@ -16,6 +16,7 @@
 /usr/ssl/certs/ca-bundle.crt
 /usr/share/pacman/
 /var/lib/pacman/local/
+/update-via-pacman.ps1
 
 # GPG agent
 /usr/bin/gpg-agent.exe


### PR DESCRIPTION
Closes https://github.com/git-for-windows/git-for-windows-automation/issues/97

When trying to work with the `build-installers` SDK artifact, it turned out that it's missing the `update-via-pacman.ps1` file. And since that artifact is using the `makepkg-git` and `minimal-sdk` file lists as its foundation, we need to update the file list here, so that said file will end up in the `build-installers` artifact.

Ref: https://github.com/git-for-windows/git-for-windows-automation/issues/97
Ref: https://github.com/git-for-windows/build-extra/blob/76751073989fa261449a2cc94b8a5defbd8958a5/please.sh#L3307