### PR TITLE
makepkg-git: include pacman-key and pacman-conf.exe as well

### DIFF
--- a/.sparse/makepkg-git
+++ b/.sparse/makepkg-git
@@ -2,6 +2,8 @@
 /.sparse/makepkg-git
 
 # Pacman
+/usr/bin/pacman-conf.exe
+/usr/bin/pacman-key
 /usr/bin/pacman.exe
 /usr/bin/pactree.exe
 /usr/bin/msys-gpg*.dll


### PR DESCRIPTION
In the previous commit, we added `/update-via-pacman.ps1` to the list of files to include in `makepkg-git` (as this list ends up in the `build-installers` artifact, which we're trying to use).

However, that script now [failed](https://github.com/git-for-windows/git-for-windows-automation/actions/runs/10929821802/job/30383106122), complaining that `pacman-conf.exe` and `pacman-key` are missing.

I confirmed locally that after adding these files manually to the `build-installers` artifact, the `.ps1` file is able to succeed.

Ref: https://github.com/git-for-windows/git-sdk-arm64/commit/fbb8e7344cf8d0ac9fcda4b8a0ea2392c8636ade