### PR TITLE
minimal-sdk: accommodate for gettext v0.23.*

### DIFF
--- a/.sparse/minimal-sdk
+++ b/.sparse/minimal-sdk
@@ -41,6 +41,7 @@
 # gettext (msgfmt)
 /clangarm64/bin/msgfmt.exe
 /clangarm64/bin/libgettext*.dll
+/clangarm64/bin/libtextstyle-*[0-9].dll
 
 # Tcl (to emulate msgfmt, *somewhere*)
 /clangarm64/bin/tclsh.exe


### PR DESCRIPTION
As of `mingw-w64-gettext-runtime` (0.22.5-2 -> 0.23.1-1), `msgfmt.exe` now depends on a newly-introduced library, gettext-libtextstyle. So let's include that in the `minimal-sdk` sparse checkout, too.

This is a companion of https://github.com/git-for-windows/git-sdk-64/pull/90 and of https://github.com/git-for-windows/git-sdk-32/pull/36