### PR TITLE
makepkg-git: accommodate for Ruby v3.4.0

### DIFF
--- a/.sparse/makepkg-git
+++ b/.sparse/makepkg-git
@@ -86,6 +86,7 @@
 /clangarm64/lib/ruby/*/aarch64-mingw-ucrt/enc/windows_1252.so
 /clangarm64/lib/ruby/*/optparse.rb
 /clangarm64/lib/ruby/*/aarch64-mingw-ucrt/strscan.so
+/clangarm64/lib/ruby/*/strscan/strscan.rb
 /clangarm64/lib/ruby/*/pathname.rb
 /clangarm64/lib/ruby/*/aarch64-mingw-ucrt/pathname.so
 /clangarm64/lib/ruby/*/did_you_mean*


### PR DESCRIPTION
In that version, `strscan` not only has a native library but also Ruby code that we need to provide to be able to run `asciidoctor` (which is used to render Git's documentation).

This is a companion to https://github.com/git-for-windows/git-sdk-64/pull/93.