### PR TITLE
Use hosted Windows/ARM64 runners even more

### DIFF
--- a/.github/workflows/check-for-missing-dlls.yml
+++ b/.github/workflows/check-for-missing-dlls.yml
@@ -36,7 +36,8 @@ jobs:
           sh -x ./build-extra/please.sh create-sdk-artifact --sdk=git-sdk-arm64.git build-installers &&
           cygpath -aw "$PWD/build-installers/usr/bin/core_perl" >>$GITHUB_PATH &&
           cygpath -aw "$PWD/build-installers/usr/bin" >>$GITHUB_PATH &&
-          cygpath -aw "$PWD/build-installers/mingw64/bin" >>$GITHUB_PATH
+          cygpath -aw "$PWD/build-installers/clangarm64/bin" >>$GITHUB_PATH &&
+          echo "MSYSTEM=CLANGARM64" >>$GITHUB_ENV
       - name: check for missing DLLs
         shell: bash
         run: ./build-extra/check-for-missing-dlls.sh

--- a/.github/workflows/check-for-missing-dlls.yml
+++ b/.github/workflows/check-for-missing-dlls.yml
@@ -1,6 +1,10 @@
 name: check-for-missing-dlls
 
 on:
+  push:
+    branches:
+      - main
+  pull_request:
   workflow_dispatch:
 
 env:

--- a/.github/workflows/ci-artifacts.yml
+++ b/.github/workflows/ci-artifacts.yml
@@ -55,7 +55,7 @@ jobs:
           make -C ../git DEVELOPER=1 NO_PERL=1 SKIP_DASHED_BUILT_INS=YesPlease -j8 all strip
       - name: show build-options
         shell: bash
-        run: ../git/git version --build-options
+        run: . /etc/profile && ../git/git version --build-options
       - name: compress git artifacts
         shell: bash
         run: tar -C .. -czf git-artifacts.tar.gz --exclude '*.a' --exclude '*.o' --exclude .git --exclude .depend git

--- a/.github/workflows/git-artifacts.yml
+++ b/.github/workflows/git-artifacts.yml
@@ -1,6 +1,9 @@
 name: git-artifacts
 
 on:
+  push:
+    branches:
+      - main
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
In #37, I switched the `sync` and `ci-artifacts` workflows in particular to use the GitHub-hosted Windows/ARM64 runners.

In the `ci-artifacts` part, I made a minor mistake that prevents the `git version --build-options` check (meant for debugging) to run correctly (because the required DLL files are not on the `PATH` when that command is run). The primary motivation for this here PR is to fix this.

The secondary focus is to get the `check-for-missing-dlls` to run correctly, and to run it automatically on `push` and in PRs.

Finally, we also enable the `git-artifacts` to run automatically on `push`, just like in `git-sdk-64`/`git-sdk-32`.

[Here](https://github.com/git-for-windows/git-sdk-arm64/actions/runs/14778379875) is a run of the `ci-artifacts` workflow, and [here](https://github.com/git-for-windows/git-sdk-arm64/actions/runs/14778379860/job/41491613925) a run of the `check-for-missing-dlls` workflow that demonstrate that this here PR works (these runs were triggered from a branch that has a couple of commits on top, purely for debugging). And [here](https://github.com/git-for-windows/git-sdk-arm64/actions/runs/14778984690) is a run of the `git-artifacts` workflow (triggered from _another_ branch that has another commit on top to trigger on `push` to _that_ branch instead of `main`).