### PR TITLE
Adapt to the layout of Ruby v4

### DIFF
--- a/.sparse/makepkg-git
+++ b/.sparse/makepkg-git
@@ -81,7 +81,7 @@
 /clangarm64/lib/ruby/gems/*/specifications/asciidoctor-*.gemspec
 /clangarm64/lib/ruby/*/tsort.rb
 /clangarm64/lib/ruby/*/set.rb
-/clangarm64/lib/ruby/*/logger.rb
+/clangarm64/lib/ruby/**/logger*
 /clangarm64/lib/ruby/*/aarch64-mingw-ucrt/enc/encdb.so
 /clangarm64/lib/ruby/*/aarch64-mingw-ucrt/enc/windows_1252.so
 /clangarm64/lib/ruby/*/optparse.rb
@@ -90,8 +90,7 @@
 /clangarm64/lib/ruby/*/pathname.rb
 /clangarm64/lib/ruby/*/aarch64-mingw-ucrt/pathname.so
 /clangarm64/lib/ruby/*/did_you_mean*
-/clangarm64/lib/ruby/*/cgi/util*
-/clangarm64/lib/ruby/*/logger*
+/clangarm64/lib/ruby/*/cgi/*
 /clangarm64/lib/ruby/*/bundled_gems.rb
 /clangarm64/lib/ruby/*/syntax_suggest*
 


### PR DESCRIPTION
After https://github.com/msys2/MINGW-packages/pull/30629 (i.e. upgrading from Ruby v3 to Ruby v4), git-sdk-arm64's `git-artifacts` workflow fails, https://github.com/git-for-windows/git-sdk-arm64/actions/runs/30686452160/job/91333143308#step:10:584

```
    ASCIIDOC git-add.html
  C:/a/git-sdk-arm64/git-sdk-arm64/build-installers/clangarm64/lib/ruby/4.0.0/cgi/util.rb:3:in 'Kernel#require': cannot load such file -- cgi/escape (LoadError)
  Did you mean?  cgi/util
	from C:/a/git-sdk-arm64/git-sdk-arm64/build-installers/clangarm64/lib/ruby/4.0.0/cgi/util.rb:3:in '<top (required)>'
	from C:/a/git-sdk-arm64/git-sdk-arm64/build-installers/clangarm64/lib/ruby/gems/4.0.0/gems/asciidoctor-2.0.26/lib/asciidoctor.rb:9:in 'Kernel#require'
	from C:/a/git-sdk-arm64/git-sdk-arm64/build-installers/clangarm64/lib/ruby/gems/4.0.0/gems/asciidoctor-2.0.26/lib/asciidoctor.rb:9:in '<top (required)>'
	from C:/a/git-sdk-arm64/git-sdk-arm64/build-installers/clangarm64/lib/ruby/gems/4.0.0/gems/asciidoctor-2.0.26/bin/asciidoctor:6:in 'Kernel#require'
	from C:/a/git-sdk-arm64/git-sdk-arm64/build-installers/clangarm64/lib/ruby/gems/4.0.0/gems/asciidoctor-2.0.26/bin/asciidoctor:6:in '<top (required)>'
	from C:/a/git-sdk-arm64/git-sdk-arm64/build-installers/clangarm64/lib/ruby/4.0.0/rubygems.rb:305:in 'Kernel#load'
	from C:/a/git-sdk-arm64/git-sdk-arm64/build-installers/clangarm64/lib/ruby/4.0.0/rubygems.rb:305:in 'Gem.activate_and_load_bin_path'
	from C:/a/git-sdk-arm64/git-sdk-arm64/build-installers/clangarm64/bin/asciidoctor:36:in '<main>'
```

The reason is a changed file layout of Ruby's gems. Let's adapt to that.